### PR TITLE
ci: install website deployment tools

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: [self-hosted, node-b, linux, x64]
     steps:
       - uses: actions/checkout@v7
+      - name: Install deployment tools
+        run: sudo apt-get update && sudo apt-get install -y rsync openssh-client
       - name: Validate website
         run: ci/tasks/website-check
       - name: Deploy website


### PR DESCRIPTION
The self-hosted public runner does not have rsync preinstalled. Install rsync and openssh-client before running the existing website deployment script.