### PR TITLE
fix(webui): use same-origin API for production route

### DIFF
--- a/crates/librtbit/webui/src/http-api.ts
+++ b/crates/librtbit/webui/src/http-api.ts
@@ -52,8 +52,14 @@ const apiUrl = (() => {
 
   const url = new URL(window.location.href);
 
-  // assume Vite devserver
-  if (url.port == "3031" || url.port == "1420") {
+  // Vite's development server runs on 3031 and forwards API requests to a
+  // separately running backend on 3030. The production web UI is served by
+  // rtbit itself under /web/ on the API port, so it must use same-origin API
+  // requests. The desktop dev shell on 1420 also talks to the backend on 3030.
+  if (url.port == "3031" && (url.pathname === "/" || url.pathname === "")) {
+    return `${url.protocol}//${url.hostname}:3030`;
+  }
+  if (url.port == "1420") {
     return `${url.protocol}//${url.hostname}:3030`;
   }
 


### PR DESCRIPTION
The production web UI is served at /web/ on the API port, but the API client treated port 3031 as the Vite dev server and redirected calls to port 3030. Use port 3030 only for the Vite root path and desktop dev shell; production /web/ uses same-origin requests. Tests: npm test --prefix crates/librtbit/webui; npm run build --prefix crates/librtbit/webui