### PR TITLE
ci: fix release dependencies on root runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install release toolchain
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 nasm
+          apt-get update
+          apt-get install -y gcc-mingw-w64-x86-64 nasm
           cargo install cargo-deb --locked
           rustup target add x86_64-pc-windows-gnu
       - name: Build Linux and Debian artifacts


### PR DESCRIPTION
The v0.1.0-beta.3 release run failed before building because the self-hosted runner executes as root and root is intentionally not in sudoers. Install the required apt packages directly, matching the runner identity, so the existing tag can be published via workflow_dispatch after merge.\n\nValidation: bash ci/migration-policy.sh; git diff --check.