### PR TITLE
ci: adopt org runner-policy gate

### DIFF
--- a/.github/workflows/runner-policy.yml
+++ b/.github/workflows/runner-policy.yml
@@ -1,0 +1,16 @@
+# Copy this file to .github/workflows/runner-policy.yml in every repository.
+#
+# It is deliberately tiny: all logic lives in the reusable workflow in
+# github-policy, so the rule can be changed in one place. After adding it, make
+# `runner-policy` a required status check on the repository's protected branch
+# — without that it reports but does not block.
+name: Runner policy
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  runner-policy:
+    uses: TheDancingDeveloper-org/github-policy/.github/workflows/runner-policy-reusable.yml@main


### PR DESCRIPTION
Rollout of indexarr/ops docs/github-actions-runner-gaps.md Phase 4 item 1. Copies templates/runner-policy-stub.yml from TheDancingDeveloper-org/github-policy verbatim. Reporting-only until runner-policy is made a required status check.