### PR TITLE
ci: drop --depth=1 base fetch in migration-policy (false positives)

### DIFF
--- a/ci/migration-policy.sh
+++ b/ci/migration-policy.sh
@@ -70,7 +70,7 @@ then
 fi
 
 if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
-  git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" >/dev/null 2>&1 || true
+  git fetch --no-tags origin "$GITHUB_BASE_REF" >/dev/null 2>&1 || true
   base="origin/$GITHUB_BASE_REF"
   commits="$(git rev-list --reverse "$base..HEAD" 2>/dev/null || git rev-list --reverse HEAD~1..HEAD 2>/dev/null || git rev-list --reverse HEAD)"
 elif [[ "${GITHUB_EVENT_NAME:-}" == push && "${GITHUB_BEFORE:-}" != 0000000000000000000000000000000000000000 ]]; then


### PR DESCRIPTION
The base ref was fetched with `--depth=1` while the workflow checks out full history; the shallow graft made `origin/BASE..HEAD` reappear historical base commits after an Update-branch merge, tripping the commit-metadata rule on commits the PR never touched. Fetch the base full-depth, matching the already-fixed variant in rustnzb. No change to what the policy forbids.