### PR TITLE
ci: dev → main → release promotion flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   # ---- Rust: main workspace (covers all crates/* and desktop/src-tauri) ----
   - package-ecosystem: cargo
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -20,6 +21,7 @@ updates:
   # ---- Rust: benchv2 (excluded from the workspace) ----
   - package-ecosystem: cargo
     directory: "/benchv2"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -32,6 +34,7 @@ updates:
   # ---- Rust: fuzz (excluded from the workspace) ----
   - package-ecosystem: cargo
     directory: "/fuzz"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -44,6 +47,7 @@ updates:
   # ---- npm: web UI (crates/librtbit/webui) ----
   - package-ecosystem: npm
     directory: "/crates/librtbit/webui"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -56,6 +60,7 @@ updates:
   # ---- npm: root workspace (includes the desktop package) ----
   - package-ecosystem: npm
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -68,6 +73,7 @@ updates:
   # ---- GitHub Actions workflows ----
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths-ignore:
       - "*.md"
       - "docs/**"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,7 +2,7 @@ name: Container publication
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     tags: ['v*']
   workflow_dispatch:
 
@@ -34,12 +34,19 @@ jobs:
         id: tags
         shell: bash
         run: |
+          # Promotion flow: dev branch -> :dev (preview), main branch ->
+          # :staging (promoted, pre-release), v* tag -> prod (:latest/:beta/:<tag>).
+          # Every build also gets an immutable :sha-<commit> tag.
           if [[ "$GITHUB_REF_TYPE" == tag ]]; then
             case "$GITHUB_REF_NAME" in v[0-9]*) ;; *) exit 1 ;; esac
             printf 'tags=%s\n' "$IMAGE:$GITHUB_REF_NAME,$IMAGE:latest,$IMAGE:beta,$IMAGE:sha-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          else
-            test "$GITHUB_REF_NAME" = main
+          elif [[ "$GITHUB_REF_NAME" == main ]]; then
+            printf 'tags=%s\n' "$IMAGE:staging,$IMAGE:sha-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF_NAME" == dev ]]; then
             printf 'tags=%s\n' "$IMAGE:dev,$IMAGE:sha-$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "container publication is not configured for ref $GITHUB_REF_NAME" >&2
+            exit 1
           fi
       - name: Build and publish the destination image once
         uses: docker/build-push-action@v7
@@ -57,7 +64,7 @@ jobs:
       # bootstrap; this anonymous pull is the fail-closed enforcement.
       - name: Verify the anonymous destination manifest
         run: |
-          if [[ "$GITHUB_REF_TYPE" == tag ]]; then tag="$GITHUB_REF_NAME"; else tag=dev; fi
+          if [[ "$GITHUB_REF_TYPE" == tag ]]; then tag="$GITHUB_REF_NAME"; elif [[ "$GITHUB_REF_NAME" == main ]]; then tag=staging; else tag=dev; fi
           token=$(curl -fsS 'https://ghcr.io/token?service=ghcr.io&scope=repository:thedancingdeveloper-org/rusttorrent:pull' | jq -r .token)
           test -n "$token"
           curl -fsS -H "Authorization: Bearer $token" \

--- a/.github/workflows/runner-policy.yml
+++ b/.github/workflows/runner-policy.yml
@@ -9,7 +9,7 @@ name: Runner policy
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   runner-policy:

--- a/documentation/ReleaseProcess.md
+++ b/documentation/ReleaseProcess.md
@@ -11,6 +11,28 @@ The current beta release is `0.1.0-beta.3`.
 - Release tag: `v0.1.0-beta.3`
 - Docker tag: `ghcr.io/thedancingdeveloper-org/rusttorrent:v0.1.0-beta.3`
 
+## Branching model
+
+Promotion flow: **`dev` → `main` → cut release (`v*` tag) → prod.**
+
+- **`dev`** is the integration branch. Feature/dependency PRs target `dev`.
+  Pushing `dev` runs CI and publishes the preview image
+  `ghcr.io/thedancingdeveloper-org/rusttorrent:dev` (+ immutable `sha-<commit>`).
+- **`main`** is the promoted, pre-release branch. Promote `dev → main` by PR.
+  Pushing `main` runs CI and publishes `…:staging` (+ `sha-<commit>`) and
+  deploys the website. `main` is protected and its version stays at the current
+  beta until a release is cut.
+- **`v*` tag** (cut from `main`) is the release lever → prod: builds the
+  binaries + `.deb`, publishes them to the download host and the GitHub release,
+  and publishes the multi-arch prod image tagged `…:<tag>`, `…:latest`, `…:beta`
+  (+ `sha-<commit>`).
+
+Nothing auto-deploys the running prod service from these workflows; publication
+is to GHCR + the download host, and the deployment platform (Komodo) pulls the
+tag it is configured for. A deployment that previously tracked `…:dev` for
+"latest main" must repoint to `…:staging`, since `…:dev` now follows the `dev`
+branch.
+
 ## CI Flow
 
 Pushes and tags run the workflows under `.github/workflows/`.
@@ -18,8 +40,8 @@ Pushes and tags run the workflows under `.github/workflows/`.
 The Rust workflow builds the workspace from GitHub. Local development keeps
 `[patch]` sections pointed at sibling crates under `../libs/`.
 
-Main branch pushes publish the public GHCR image as `dev` and an immutable
-`sha-<commit>` tag.
+`dev` branch pushes publish the GHCR image as `dev`; `main` branch pushes
+publish it as `staging`; both add an immutable `sha-<commit>` tag.
 
 Release tags build:
 


### PR DESCRIPTION
Introduces a `dev` integration branch and the **dev → main → cut-release (v* tag) → prod** promotion flow.

## Pipeline changes
- **container.yml** — per-stage image tags: `dev`→`:dev` (preview), `main`→`:staging` (promoted/pre-release), `v*` tag→prod (`:latest`/`:beta`/`:<tag>`); every build keeps immutable `:sha-<commit>`. Anonymous manifest verification matches the stage.
- **ci.yml** + **runner-policy.yml** — also run on `dev` pushes (PRs already run regardless of base).
- **ReleaseProcess.md** — documents the branching model and tag re-mapping.

## Flow
```
PRs ──▶ dev ──(promote by PR)──▶ main ──(cut v* tag)──▶ prod
        :dev                     :staging               :latest/:beta/:<tag>
```

⚠️ **Deploy note:** `…:dev` now follows the `dev` branch. Any deployment (Komodo) that pulled `…:dev` for 'latest main' should repoint to `…:staging`.

This PR is itself the first `dev → main` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)