### PR TITLE
ci: migrate runner selectors off retired node-b label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   rust:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     env:
       CARGO_BUILD_JOBS: 1
     steps:
@@ -39,7 +39,7 @@ jobs:
       - run: cargo build --profile release-github -p rtbit --no-default-features --features default-tls
 
   webui:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -57,7 +57,7 @@ jobs:
         run: npm run build
 
   gui-e2e:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     needs: webui
     steps:
       - uses: actions/checkout@v7
@@ -74,7 +74,7 @@ jobs:
         run: npm run test:e2e
 
   website:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v7
       - run: ci/tasks/website-check

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     # Privileged publication capacity is selected only for this repository and
     # this workflow deliberately has no pull_request trigger.
-    runs-on: [self-hosted, node-b, linux, x64, publish, docker]
+    runs-on: [self-hosted, docker, publish]
     env:
       IMAGE: ghcr.io/thedancingdeveloper-org/rusttorrent
     steps:

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   policy:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     env:
       CARGO_BUILD_JOBS: 1
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, node-b, linux, x64]
+    runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v7
       - name: Validate website


### PR DESCRIPTION
Completes the 2026-08-19 runner-label convention ("labels are capabilities, not locations; `rust` is a fiction"). Part of the fleet-wide migration tracked in Vogt WI-25; canaried on rustnzb#120 where jobs were verified running and passing on the previously idle node-f runners.

| before | after |
|---|---|
| `[self-hosted, node-b, linux, x64]` / `[self-hosted, node-b]` | `[self-hosted]` |
| `[self-hosted, node-b, linux, x64, publish, docker]` | `[self-hosted, docker, publish]` |

Bare `[self-hosted]` matches every existing runner (all carry the default `self-hosted/Linux/X64` labels), so this only widens the pool. Jobs needing DinD keep `docker`/`publish` and still land on the node-b workers.

Merging every repo still selecting `node-b` unblocks re-registering the stale runners so their live labels match the ops compose files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjwX7G4UVdpDpVo4bkpGvi